### PR TITLE
feat(file-list): 動画ファイルのサムネイルに動画アイコンを追加

### DIFF
--- a/src/components/MediaBrowser/FileList.css
+++ b/src/components/MediaBrowser/FileList.css
@@ -84,6 +84,28 @@
   accent-color: #1976d2;
 }
 
+/* Video indicator icon - same position as checkbox */
+.video-indicator {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.6);
+  border-radius: 4px;
+  color: white;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.video-indicator svg {
+  width: 14px;
+  height: 14px;
+}
+
 .file-list-item {
   position: relative;
 }

--- a/src/components/MediaBrowser/FileList.test.tsx
+++ b/src/components/MediaBrowser/FileList.test.tsx
@@ -318,6 +318,100 @@ describe("FileList", () => {
     });
   });
 
+  describe("動画アイコン表示", () => {
+    it("動画ファイルのサムネイルに動画アイコンが表示される", () => {
+      render(<FileList items={mockItems} onFolderClick={vi.fn()} onFileClick={vi.fn()} />, {
+        wrapper,
+      });
+
+      const videoIndicator = screen.getByLabelText("動画ファイル");
+      expect(videoIndicator).toBeInTheDocument();
+      expect(videoIndicator).toHaveClass("video-indicator");
+    });
+
+    it("画像ファイルには動画アイコンが表示されない", () => {
+      render(<FileList items={mockItems} onFolderClick={vi.fn()} onFileClick={vi.fn()} />, {
+        wrapper,
+      });
+
+      // 動画アイコンは1つだけ（video.mp4のみ）
+      const videoIndicators = screen.getAllByLabelText("動画ファイル");
+      expect(videoIndicators).toHaveLength(1);
+    });
+
+    it("フォルダには動画アイコンが表示されない", () => {
+      const folderOnly: StorageItem[] = [{ key: "folder1/", name: "folder1", type: "folder" }];
+      render(<FileList items={folderOnly} onFolderClick={vi.fn()} onFileClick={vi.fn()} />, {
+        wrapper,
+      });
+
+      expect(screen.queryByLabelText("動画ファイル")).not.toBeInTheDocument();
+    });
+
+    it("選択モード時は動画アイコンが非表示になる", () => {
+      render(
+        <FileList
+          items={mockItems}
+          onFolderClick={vi.fn()}
+          onFileClick={vi.fn()}
+          isSelectionMode={true}
+          selectedKeys={new Set()}
+          onToggleSelection={vi.fn()}
+        />,
+        { wrapper },
+      );
+
+      expect(screen.queryByLabelText("動画ファイル")).not.toBeInTheDocument();
+    });
+
+    it("選択モード解除後に動画アイコンが再表示される", () => {
+      const { unmount } = render(
+        <FileList
+          items={mockItems}
+          onFolderClick={vi.fn()}
+          onFileClick={vi.fn()}
+          isSelectionMode={true}
+          selectedKeys={new Set()}
+          onToggleSelection={vi.fn()}
+        />,
+        { wrapper },
+      );
+
+      // 選択モード時は非表示
+      expect(screen.queryByLabelText("動画ファイル")).not.toBeInTheDocument();
+
+      // 一度アンマウントして再レンダリング
+      unmount();
+
+      render(
+        <FileList
+          items={mockItems}
+          onFolderClick={vi.fn()}
+          onFileClick={vi.fn()}
+          isSelectionMode={false}
+        />,
+        { wrapper },
+      );
+
+      // 動画アイコンが再表示される
+      expect(screen.getByLabelText("動画ファイル")).toBeInTheDocument();
+    });
+
+    it("複数の動画ファイルがある場合、各ファイルに動画アイコンが表示される", () => {
+      const multiVideoItems: StorageItem[] = [
+        { key: "video1.mp4", name: "video1.mp4", type: "file", size: 1024 },
+        { key: "video2.webm", name: "video2.webm", type: "file", size: 2048 },
+        { key: "video3.mov", name: "video3.mov", type: "file", size: 3072 },
+      ];
+      render(<FileList items={multiVideoItems} onFolderClick={vi.fn()} onFileClick={vi.fn()} />, {
+        wrapper,
+      });
+
+      const videoIndicators = screen.getAllByLabelText("動画ファイル");
+      expect(videoIndicators).toHaveLength(3);
+    });
+  });
+
   describe("keyboard accessibility", () => {
     it("Space キーでチェックボックスが操作できる", () => {
       const onToggleSelection = vi.fn();

--- a/src/components/MediaBrowser/FileList.tsx
+++ b/src/components/MediaBrowser/FileList.tsx
@@ -1,5 +1,5 @@
 import { useRef, useCallback } from "react";
-import { Folder, Image, Film, File } from "lucide-react";
+import { Folder, Image, Film, File, Video } from "lucide-react";
 import { SimpleGrid, Center, Text, Checkbox } from "@mantine/core";
 import { useLongPress } from "@mantine/hooks";
 import type { StorageItem } from "../../types/storage";
@@ -147,7 +147,7 @@ function FileListItem({
       role="listitem"
       {...eventHandlers}
     >
-      {isSelectionMode && (
+      {isSelectionMode ? (
         <Checkbox
           checked={isSelected}
           onChange={() => {}}
@@ -155,6 +155,12 @@ function FileListItem({
           aria-label={`${item.name} を選択`}
           classNames={{ root: "file-list-checkbox" }}
         />
+      ) : (
+        getFileType(item) === "video" && (
+          <span className="video-indicator" aria-label="動画ファイル">
+            <Video aria-hidden="true" />
+          </span>
+        )
       )}
       {shouldShowThumbnail(item) ? (
         <Thumbnail originalKey={item.key} fileName={item.name} fileType={getFileType(item)!} />


### PR DESCRIPTION
- 動画ファイル（.mp4, .webm, .mov）のサムネイル左上に動画アイコンを表示
- 選択モード時はチェックボックスのみ表示（動画アイコンは非表示）
- Lucide React の Video アイコンを使用
- テストケース6件を追加