### PR TITLE
feat: Renovate による依存関係自動アップデートを設定

### DIFF
--- a/.kiro/specs/automated-dependency-updates/design.md
+++ b/.kiro/specs/automated-dependency-updates/design.md
@@ -1,0 +1,438 @@
+# Design Document: Automated Dependency Updates
+
+## Overview
+
+**Purpose**: Renovate GitHub App を導入し、npm 依存関係と Node.js ランタイムバージョンの自動アップデートを実現する。
+
+**Users**: 開発者がプルリクエストベースで依存関係の更新をレビュー・マージできるようになる。
+
+**Impact**: 手動での依存関係管理の負担を軽減し、セキュリティパッチの適用を迅速化する。
+
+### Goals
+
+- Renovate GitHub App による依存関係の自動監視と PR 作成
+- 関連パッケージのグループ化によるレビュー負担の軽減
+- devDependencies パッチアップデートの自動マージによる運用コスト削減
+- `.tool-versions` ファイルの Node.js バージョン管理
+
+### Non-Goals
+
+- Dependabot との併用（Renovate 単独で全要件をカバー）
+- セルフホスティング（GitHub App を使用）
+- production dependencies の自動マージ（手動レビュー必須）
+- Amplify バックエンド（Lambda）の Node.js バージョン管理（別途対応）
+
+## Architecture
+
+### Architecture Pattern & Boundary Map
+
+本機能は設定ファイルの追加のみで完結し、アプリケーションコードの変更は不要。
+
+```mermaid
+graph TB
+    subgraph GitHub
+        Repo[Repository]
+        PR[Pull Requests]
+        CI[CI Workflow]
+    end
+
+    subgraph Renovate
+        App[Renovate GitHub App]
+        Config[renovate.json]
+    end
+
+    subgraph Files
+        PKG[package.json]
+        LOCK[package-lock.json]
+        TOOL[.tool-versions]
+    end
+
+    App -->|reads| Config
+    App -->|monitors| PKG
+    App -->|monitors| LOCK
+    App -->|monitors| TOOL
+    App -->|creates| PR
+    PR -->|triggers| CI
+    CI -->|runs| NPM[npm run check-all]
+    PR -->|automerge if CI passes| Repo
+```
+
+**Architecture Integration**:
+
+- Selected pattern: 外部サービス連携（GitHub App）
+- Domain/feature boundaries: CI/CD パイプラインの拡張、アプリケーションコードとは独立
+- Existing patterns preserved: 既存の CI ワークフロー（`.github/workflows/ci.yml`）をそのまま活用
+- New components rationale: `renovate.json` のみ追加、既存ファイルへの変更なし
+- Steering compliance: 運用コスト最小化、Amplify 統合バックエンドとの親和性
+
+### Technology Stack
+
+| Layer           | Choice / Version    | Role in Feature              | Notes                               |
+| --------------- | ------------------- | ---------------------------- | ----------------------------------- |
+| Automation      | Renovate GitHub App | 依存関係監視・PR 作成        | Mend 提供の無料ホスティングサービス |
+| Configuration   | renovate.json       | ツール設定                   | JSON 形式、リポジトリルートに配置   |
+| Package Manager | npm (asdf manager)  | 依存関係・ランタイム管理対象 | `package.json`, `.tool-versions`    |
+| CI/CD           | GitHub Actions      | PR 検証                      | 既存の `ci.yml` を使用              |
+
+## Requirements Traceability
+
+| Requirement | Summary                           | Components             | Interfaces | Flows          |
+| ----------- | --------------------------------- | ---------------------- | ---------- | -------------- |
+| 1.1         | GitHub で利用可能なツール使用     | RenovateConfig         | -          | -              |
+| 1.2         | 設定ファイルの配置場所            | RenovateConfig         | -          | -              |
+| 1.3         | リポジトリスキャン                | Renovate App           | -          | DependencyScan |
+| 1.4         | dependencies/devDependencies 対象 | RenovateConfig         | -          | -              |
+| 2.1         | PR 自動作成                       | Renovate App           | -          | PRCreation     |
+| 2.2         | パッケージ・バージョン情報明記    | Renovate App           | -          | -              |
+| 2.3         | changelog リンク                  | Renovate App           | -          | -              |
+| 2.4         | CI トリガー                       | GitHub Actions         | -          | CIValidation   |
+| 3.1         | 週次チェック                      | RenovateConfig         | -          | -              |
+| 3.2         | セキュリティ優先                  | RenovateConfig         | -          | -              |
+| 3.3         | スケジュール変更可能              | RenovateConfig         | -          | -              |
+| 4.1         | パッケージグループ化              | RenovateConfig         | -          | -              |
+| 4.2         | devDependencies グループ化        | RenovateConfig         | -          | -              |
+| 4.3         | メジャーアップデート個別 PR       | RenovateConfig         | -          | -              |
+| 5.1         | パッチ自動マージ設定              | RenovateConfig         | -          | Automerge      |
+| 5.2         | CI 成功時自動マージ               | RenovateConfig, GitHub | -          | Automerge      |
+| 5.3         | CI 失敗時手動レビュー             | RenovateConfig         | -          | -              |
+| 5.4         | devDependencies のみ自動マージ    | RenovateConfig         | -          | -              |
+| 6.1         | パッケージ除外機能                | RenovateConfig         | -          | -              |
+| 6.2         | バージョン固定機能                | RenovateConfig         | -          | -              |
+| 6.3         | overrides 考慮                    | RenovateConfig         | -          | -              |
+| 7.1         | .tool-versions 監視               | Renovate asdf Manager  | -          | -              |
+| 7.2         | Node.js LTS アップデート PR       | Renovate App           | -          | NodeUpdate     |
+| 7.3         | Node.js 個別 PR                   | RenovateConfig         | -          | -              |
+
+## Components and Interfaces
+
+| Component           | Domain/Layer     | Intent                | Req Coverage                                         | Key Dependencies  | Contracts |
+| ------------------- | ---------------- | --------------------- | ---------------------------------------------------- | ----------------- | --------- |
+| RenovateConfig      | Configuration    | Renovate の動作設定   | 1.1-1.4, 3.1-3.3, 4.1-4.3, 5.1-5.4, 6.1-6.3, 7.1-7.3 | Renovate App (P0) | State     |
+| Renovate GitHub App | External Service | 依存関係監視・PR 作成 | 2.1-2.4, 7.2                                         | GitHub API (P0)   | Service   |
+
+### Configuration Layer
+
+#### RenovateConfig
+
+| Field        | Detail                                               |
+| ------------ | ---------------------------------------------------- |
+| Intent       | Renovate の動作を制御する設定ファイル                |
+| Requirements | 1.1-1.4, 3.1-3.3, 4.1-4.3, 5.1-5.4, 6.1-6.3, 7.1-7.3 |
+
+**Responsibilities & Constraints**
+
+- 依存関係のスキャン対象（npm, asdf）の指定
+- アップデートスケジュールの制御
+- パッケージグループ化ルールの定義
+- 自動マージ条件の設定
+- 除外パッケージの指定
+
+**Dependencies**
+
+- External: Renovate GitHub App — 設定の読み取りと実行 (P0)
+- External: GitHub API — PR 作成・マージ (P0)
+
+**Contracts**: State [x]
+
+##### State Management
+
+```json5
+{
+  // IDE での入力補完・検証を有効化する JSON Schema 参照
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+
+  // 継承するプリセット設定
+  // - config:recommended: Renovate 推奨設定（セマンティックバージョニング分類、適切なデフォルト値）
+  // - :disableDependencyDashboard: Dashboard Issue を無効化し、PR のみで管理
+  extends: ["config:recommended", ":disableDependencyDashboard"],
+
+  // スケジュール評価に使用するタイムゾーン
+  timezone: "Asia/Tokyo",
+
+  // アップデートチェックのスケジュール（毎週月曜 9:00 前）
+  schedule: ["before 9am on monday"],
+
+  // 1時間あたりの PR 作成上限（ノイズ軽減）
+  prHourlyLimit: 5,
+
+  // 同時にオープンできる PR の最大数
+  prConcurrentLimit: 10,
+
+  // 有効にするパッケージマネージャー
+  // - npm: package.json の依存関係
+  // - asdf: .tool-versions の Node.js バージョン
+  enabledManagers: ["npm", "asdf"],
+
+  packageRules: [
+    // ===== パッケージグループ化ルール =====
+    // 関連パッケージを単一の PR にまとめ、レビュー負担を軽減
+
+    // AWS Amplify: バージョン互換性を保つため一括更新
+    {
+      description: "AWS Amplify packages",
+      matchPackagePatterns: ["^@aws-amplify/", "^aws-amplify$"],
+      groupName: "aws-amplify",
+    },
+
+    // TanStack (React Query 等): 内部依存があるため一括更新
+    {
+      description: "TanStack packages",
+      matchPackagePatterns: ["^@tanstack/"],
+      groupName: "tanstack",
+    },
+
+    // Mantine UI: コンポーネント間の整合性を保つため一括更新
+    {
+      description: "Mantine packages",
+      matchPackagePatterns: ["^@mantine/"],
+      groupName: "mantine",
+    },
+
+    // テスト関連: 開発ワークフローへの影響が類似
+    {
+      description: "Testing packages",
+      matchPackagePatterns: ["^@testing-library/", "^vitest$", "^@vitest/"],
+      groupName: "testing",
+    },
+
+    // 型定義: 低リスクのため一括更新
+    {
+      description: "Type definitions",
+      matchPackagePatterns: ["^@types/"],
+      groupName: "types",
+    },
+
+    // ===== 自動マージ設定 =====
+    // devDependencies のパッチアップデートのみ自動マージ
+    // - 本番依存 (dependencies) は手動レビュー必須
+    // - minor/major アップデートは手動レビュー必須
+    {
+      description: "Automerge devDependencies patch updates",
+      matchDepTypes: ["devDependencies"],
+      matchUpdateTypes: ["patch"],
+      automerge: true,
+      automergeType: "pr", // PR 経由でマージ
+      automergeStrategy: "squash", // squash マージで履歴をクリーンに
+    },
+
+    // devDependencies のマイナーアップデートをグループ化
+    {
+      description: "Group devDependencies minor updates",
+      matchDepTypes: ["devDependencies"],
+      matchUpdateTypes: ["minor"],
+      groupName: "devDependencies-minor",
+    },
+
+    // ===== Node.js バージョン管理 =====
+    // .tool-versions の Node.js を監視
+    // - メジャー/マイナーを別々の PR で作成（影響度を明確化）
+    // - ランタイム変更は手動レビュー必須
+    {
+      description: "Node.js updates as separate PRs",
+      matchManagers: ["asdf"],
+      matchPackageNames: ["node"],
+      separateMajorMinor: true,
+      automerge: false,
+    },
+  ],
+
+  // ===== セキュリティアラート =====
+  // 脆弱性発見時は通常スケジュールを無視して即座に PR 作成
+  vulnerabilityAlerts: {
+    enabled: true,
+    schedule: ["at any time"],
+  },
+}
+```
+
+- State model: JSON 設定ファイル（`renovate.json`）、リポジトリルートに配置
+- Persistence & consistency: Git によるバージョン管理
+- Concurrency strategy: N/A（静的設定）
+
+**設定の拡張例**
+
+```json5
+// 特定パッケージを除外する場合
+{
+  "description": "Exclude problematic package",
+  "matchPackageNames": ["problematic-package"],
+  "enabled": false
+}
+
+// 特定バージョンを固定する場合
+{
+  "description": "Pin react to v18.x",
+  "matchPackageNames": ["react", "react-dom"],
+  "allowedVersions": "18.x"
+}
+```
+
+**Implementation Notes**
+
+- Integration: Renovate GitHub App をリポジトリにインストール後、設定が自動読み込みされる
+- Validation: JSON Schema による設定検証（`$schema` プロパティ）
+- Risks: Branch protection rules で Renovate の automerge がブロックされる可能性 → bypass 設定が必要
+
+## System Flows
+
+### DependencyScan Flow
+
+```mermaid
+sequenceDiagram
+    participant R as Renovate App
+    participant G as GitHub
+    participant C as renovate.json
+    participant P as package.json
+    participant T as .tool-versions
+
+    R->>C: Read configuration
+    R->>P: Scan dependencies
+    R->>T: Scan Node.js version
+    R->>R: Check npm registry
+    R->>R: Check Node.js releases
+    alt Updates found
+        R->>G: Create PR
+        G->>G: Trigger CI workflow
+    else No updates
+        R->>R: Wait for next schedule
+    end
+```
+
+### Automerge Flow
+
+```mermaid
+sequenceDiagram
+    participant R as Renovate App
+    participant G as GitHub
+    participant CI as CI Workflow
+    participant PR as Pull Request
+
+    R->>G: Create PR for devDependencies patch
+    G->>CI: Trigger ci.yml
+    CI->>CI: npm run check-all
+    alt CI passes
+        CI->>PR: Status check success
+        R->>G: Automerge PR with squash
+    else CI fails
+        CI->>PR: Status check failure
+        R->>PR: Add label for manual review
+    end
+```
+
+## Data Models
+
+### Domain Model
+
+本機能にはアプリケーションデータモデルの変更はない。Renovate の設定が唯一のデータ構造。
+
+### Configuration Schema
+
+```typescript
+interface RenovateConfig {
+  $schema: string;
+  extends: string[];
+  timezone: string;
+  schedule: string[];
+  prHourlyLimit: number;
+  prConcurrentLimit: number;
+  enabledManagers: ("npm" | "asdf")[];
+  packageRules: PackageRule[];
+  vulnerabilityAlerts: VulnerabilityAlertConfig;
+}
+
+interface PackageRule {
+  description?: string;
+  matchPackagePatterns?: string[];
+  matchPackageNames?: string[];
+  matchDepTypes?: ("dependencies" | "devDependencies")[];
+  matchUpdateTypes?: ("major" | "minor" | "patch" | "digest")[];
+  matchManagers?: ("npm" | "asdf")[];
+  groupName?: string;
+  automerge?: boolean;
+  automergeType?: "pr" | "branch";
+  automergeStrategy?: "merge" | "rebase" | "squash";
+  separateMajorMinor?: boolean;
+  enabled?: boolean;
+}
+
+interface VulnerabilityAlertConfig {
+  enabled: boolean;
+  schedule: string[];
+}
+```
+
+## Error Handling
+
+### Error Strategy
+
+Renovate は外部サービスとして動作するため、アプリケーション側でのエラーハンドリングは不要。
+
+### Error Categories and Responses
+
+| エラー種別 | 原因                           | 対応                                    |
+| ---------- | ------------------------------ | --------------------------------------- |
+| 設定エラー | renovate.json の構文・設定ミス | Renovate が PR 上でエラーコメントを表示 |
+| CI 失敗    | テスト・ビルドエラー           | 自動マージをスキップ、手動レビュー      |
+| マージ競合 | 依存関係の競合                 | Renovate が自動リベース、または手動解決 |
+| レート制限 | GitHub API 制限                | Renovate が自動的にリトライ             |
+
+### Monitoring
+
+- Renovate の Dependency Dashboard（オプション、現設定では無効）で更新状況を確認可能
+- GitHub の Pull Requests 一覧で Renovate の PR をフィルタリング
+
+## Testing Strategy
+
+### Configuration Validation
+
+- JSON Schema による `renovate.json` の構文検証
+- Renovate の `--dry-run` モードでの設定テスト（オプション）
+
+### Integration Testing
+
+- Renovate インストール後、初回スキャンで PR が正しく作成されることを確認
+- devDependencies パッチアップデートの自動マージが動作することを確認
+- `.tool-versions` の Node.js バージョン検出を確認
+
+### CI Integration
+
+- 既存の CI ワークフロー（`npm run check-all`）がそのまま動作することを確認
+- Branch protection rules との互換性を確認
+
+## Optional Sections
+
+### Security Considerations
+
+- **GitHub App 権限**: Renovate は PR 作成・マージに必要な最小権限のみを要求
+- **自動マージリスク**: devDependencies のパッチのみに限定し、リスクを最小化
+- **セキュリティアラート**: `vulnerabilityAlerts.enabled: true` で脆弱性を即時通知
+
+### Migration Strategy
+
+1. **Phase 1: Renovate App インストール**
+   - GitHub Marketplace から Renovate App をインストール
+   - リポジトリへのアクセスを許可
+
+2. **Phase 2: 設定ファイル追加**
+   - `renovate.json` をリポジトリルートに追加
+   - PR でレビュー・マージ
+
+3. **Phase 3: 動作確認**
+   - 初回スキャン後の PR を確認
+   - 自動マージの動作を検証
+
+4. **Phase 4: Branch Protection 調整**（必要に応じて）
+   - Renovate を bypass 対象に追加（自動マージ有効化のため）
+
+## Supporting References
+
+### Renovate プリセット一覧
+
+| プリセット                    | 説明                          |
+| ----------------------------- | ----------------------------- |
+| `config:recommended`          | 推奨設定（旧 `config:base`）  |
+| `:disableDependencyDashboard` | Dashboard Issue を無効化      |
+| `schedule:weekly`             | 週次スケジュール              |
+| `group:allNonMajor`           | 全ての non-major をグループ化 |
+
+詳細な調査結果は `research.md` を参照。

--- a/.kiro/specs/automated-dependency-updates/requirements.md
+++ b/.kiro/specs/automated-dependency-updates/requirements.md
@@ -1,0 +1,81 @@
+# Requirements Document
+
+## Introduction
+
+本ドキュメントは、AWS S3 Photo Browser プロジェクトに対して Renovate や Dependabot のような依存関係自動アップデート機能を導入するための要件を定義します。
+プロジェクトは GitHub でホストされ、npm を使用した Node.js/React アプリケーションです。既存の CI ワークフロー（`.github/workflows/ci.yml`）と統合し、セキュリティと保守性を向上させることを目的とします。
+
+## Requirements
+
+### Requirement 1: 自動アップデートツールの選定と設定
+
+**Objective:** As a 開発者, I want 依存関係の自動アップデートツールが適切に設定されている, so that 手動での依存関係管理の負担を軽減できる
+
+#### Acceptance Criteria
+
+1. The 自動アップデートシステム shall GitHub リポジトリで利用可能なツール（Renovate または Dependabot）を使用する
+2. The 設定ファイル shall リポジトリのルートまたは `.github/` ディレクトリに配置される
+3. When 設定ファイルが存在する場合, the 自動アップデートシステム shall リポジトリの依存関係をスキャンする
+4. The 設定 shall package.json の dependencies および devDependencies を対象とする
+
+### Requirement 2: プルリクエストの自動作成
+
+**Objective:** As a 開発者, I want 依存関係のアップデートがプルリクエストとして自動作成される, so that 変更内容をレビューしてからマージできる
+
+#### Acceptance Criteria
+
+1. When 新しいバージョンの依存関係が検出された場合, the 自動アップデートシステム shall プルリクエストを自動作成する
+2. The プルリクエスト shall 更新対象のパッケージ名、現在のバージョン、新しいバージョンを明記する
+3. The プルリクエスト shall 変更履歴（changelog）へのリンクを含む（利用可能な場合）
+4. When プルリクエストが作成された場合, the 自動アップデートシステム shall 既存の CI ワークフロー（`npm run check-all`）をトリガーする
+
+### Requirement 3: アップデート頻度とスケジュール
+
+**Objective:** As a 開発者, I want アップデートチェックが適切な頻度で実行される, so that セキュリティパッチを迅速に適用しつつノイズを最小化できる
+
+#### Acceptance Criteria
+
+1. The 自動アップデートシステム shall 週次でアップデートをチェックする
+2. Where セキュリティアップデートが検出された場合, the 自動アップデートシステム shall 通常のスケジュールより優先して処理する
+3. The スケジュール shall 設定ファイルで変更可能である
+
+### Requirement 4: グループ化とバッチ処理
+
+**Objective:** As a 開発者, I want 関連する依存関係のアップデートがグループ化される, so that レビューの負担を軽減できる
+
+#### Acceptance Criteria
+
+1. The 自動アップデートシステム shall 同一パッケージグループ（例: @aws-amplify/_, @tanstack/_, @mantine/\*）のアップデートを単一のプルリクエストにグループ化する
+2. The 自動アップデートシステム shall devDependencies のマイナー/パッチアップデートをグループ化する設定を持つ
+3. When メジャーアップデートが検出された場合, the 自動アップデートシステム shall 個別のプルリクエストとして作成する
+
+### Requirement 5: 自動マージ設定
+
+**Objective:** As a 開発者, I want 低リスクのアップデートが自動マージされる, so that メンテナンスオーバーヘッドを削減できる
+
+#### Acceptance Criteria
+
+1. The 自動アップデートシステム shall パッチバージョンアップデートの自動マージを設定可能とする
+2. While CI チェックが成功している場合, the 自動アップデートシステム shall 自動マージの対象とする
+3. If CI チェックが失敗した場合, then the 自動アップデートシステム shall 自動マージを行わず手動レビューを要求する
+4. The 自動マージ設定 shall devDependencies のみを対象とし、dependencies は手動マージを必須とする
+
+### Requirement 6: 除外設定
+
+**Objective:** As a 開発者, I want 特定のパッケージをアップデート対象から除外できる, so that 互換性の問題を回避できる
+
+#### Acceptance Criteria
+
+1. The 設定 shall 特定のパッケージを自動アップデート対象から除外する機能を持つ
+2. The 設定 shall 特定のバージョン範囲を固定する機能を持つ
+3. When package.json の overrides セクションに定義がある場合, the 自動アップデートシステム shall 該当パッケージの扱いに注意を払う
+
+### Requirement 7: Node.js バージョン管理
+
+**Objective:** As a 開発者, I want Node.js ランタイムのバージョンも管理対象に含める, so that ランタイム環境を最新に保てる
+
+#### Acceptance Criteria
+
+1. The 自動アップデートシステム shall `.tool-versions` ファイルの Node.js バージョンを監視対象に含める
+2. When Node.js の新しい LTS バージョンが利用可能になった場合, the 自動アップデートシステム shall プルリクエストを作成する
+3. The Node.js アップデート shall メジャーバージョンアップデートとして扱い、個別のプルリクエストとする

--- a/.kiro/specs/automated-dependency-updates/research.md
+++ b/.kiro/specs/automated-dependency-updates/research.md
@@ -1,0 +1,146 @@
+# Research & Design Decisions
+
+## Summary
+
+- **Feature**: `automated-dependency-updates`
+- **Discovery Scope**: Simple Addition（設定ファイル追加のみ、コード変更なし）
+- **Key Findings**:
+  - Renovate が Dependabot より優れた選択肢（グループ化、`.tool-versions` サポート、自動マージ機能）
+  - Dependabot は `.tool-versions` を公式サポートしていない
+  - Renovate GitHub App は無料で利用可能、設定はリポジトリ内の JSON ファイルで管理
+
+## Research Log
+
+### Renovate vs Dependabot 比較
+
+- **Context**: 要件を満たす最適なツールの選定
+- **Sources Consulted**:
+  - [Renovate Bot Comparison](https://docs.renovatebot.com/bot-comparison/)
+  - [TurboStarter Blog: Renovate vs Dependabot](https://www.turbostarter.dev/blog/renovate-vs-dependabot-whats-the-best-tool-to-automate-your-dependency-updates)
+  - [PullNotifier Blog: Comparison](https://blog.pullnotifier.com/blog/dependabot-vs-renovate-dependency-update-tools)
+- **Findings**:
+  | 機能 | Renovate | Dependabot |
+  |------|----------|------------|
+  | パッケージマネージャー | 90+ | 14 |
+  | プラットフォーム | GitHub/GitLab/Bitbucket/Azure | GitHub/Azure のみ |
+  | グループ化 | 組み込み（コミュニティ提供） | 手動設定必須 |
+  | `.tool-versions` | ネイティブサポート | 非対応 |
+  | 自動マージ | 柔軟な設定 | 限定的 |
+  | Dependency Dashboard | あり | なし |
+  | セットアップ | 設定ファイル必要 | GitHub UI から即時有効化 |
+- **Implications**: Renovate が要件 7（Node.js バージョン管理）を満たす唯一の選択肢
+
+### Renovate asdf Manager
+
+- **Context**: 要件 7 の `.tool-versions` ファイル監視機能の確認
+- **Sources Consulted**:
+  - [Renovate asdf Manager Documentation](https://docs.renovatebot.com/modules/manager/asdf/)
+  - [kachick/renovate-config-asdf](https://github.com/kachick/renovate-config-asdf)
+  - [GitHub Issue: Support ASDF versions file](https://github.com/renovatebot/renovate/issues/9759)
+- **Findings**:
+  - デフォルトで `/(^|/)\.tool-versions$/` パターンを検出
+  - node-version データソースをネイティブサポート
+  - 最初のバージョンエントリのみ管理（フォールバックバージョンは対象外）
+  - 追加ツールサポートには `kachick/renovate-config-asdf` プリセット拡張が利用可能
+- **Implications**: Node.js 22.21.1 のアップデートを自動検出可能
+
+### Dependabot の .tool-versions サポート状況
+
+- **Context**: Dependabot が要件 7 を満たせるか確認
+- **Sources Consulted**:
+  - [GitHub Issue: support asdf version manager](https://github.com/dependabot/dependabot-core/issues/1033)
+  - [asdf-vm/actions](https://github.com/asdf-vm/actions)
+- **Findings**:
+  - Dependabot は `.tool-versions` を公式サポートしていない
+  - 新しいエコシステムの追加は現在受け付けていない
+  - ワークアラウンドとして GitHub Actions で asdf コマンドを使用する方法があるが複雑
+- **Implications**: Dependabot では要件 7 を満たせない
+
+### Renovate 自動マージ設定
+
+- **Context**: 要件 5 の自動マージ機能の設定方法
+- **Sources Consulted**:
+  - [Renovate Automerge Documentation](https://docs.renovatebot.com/key-concepts/automerge/)
+  - [Renovate Configuration Options](https://docs.renovatebot.com/configuration-options/)
+- **Findings**:
+  - `matchDepTypes: ["devDependencies"]` で開発依存のみを対象にできる
+  - `matchUpdateTypes: ["patch"]` でパッチアップデートのみに限定可能
+  - `automergeType: "branch"` で PR を作成せずにブランチマージ（ノイズ軽減）
+  - CI テスト通過が自動マージの前提条件（`ignoreTests: true` でオーバーライド可能）
+  - Branch protection rules で Renovate をバイパス対象に設定する必要あり
+- **Implications**: 要件 5 の全ての受け入れ基準を満たせる
+
+### Renovate パッケージグループ化
+
+- **Context**: 要件 4 のグループ化設定方法
+- **Sources Consulted**:
+  - [Renovate Package Rules Guide](https://docs.mend.io/wsk/renovate-package-rules-guide)
+  - [Renovate FAQ](https://docs.renovatebot.com/faq/)
+- **Findings**:
+  - `matchPackagePatterns` と `groupName` でパッケージをグループ化
+  - `config:recommended` プリセットに多くの組み込みグループあり
+  - 複数ルールがマッチした場合、後のルールが優先
+- **Implications**: `@aws-amplify/*`, `@tanstack/*`, `@mantine/*` のグループ化が簡単に設定可能
+
+## Architecture Pattern Evaluation
+
+| Option               | Description                     | Strengths                        | Risks / Limitations                       | Notes               |
+| -------------------- | ------------------------------- | -------------------------------- | ----------------------------------------- | ------------------- |
+| Renovate GitHub App  | Mend 提供のホスティングサービス | セットアップ不要、無料、自動更新 | 外部サービス依存                          | 推奨                |
+| Renovate Self-hosted | GitHub Actions で実行           | 完全な制御                       | 設定・メンテナンスコスト                  | 不要                |
+| Dependabot           | GitHub ネイティブ               | 即時有効化                       | `.tool-versions` 非対応、グループ化限定的 | 要件 7 を満たせない |
+
+## Design Decisions
+
+### Decision: Renovate を選択
+
+- **Context**: 依存関係自動アップデートツールの選定
+- **Alternatives Considered**:
+  1. Dependabot — GitHub ネイティブ、セットアップ簡単
+  2. Renovate GitHub App — 高機能、柔軟な設定
+  3. 両方併用 — 役割分担
+- **Selected Approach**: Renovate GitHub App を単独使用
+- **Rationale**:
+  - 要件 7（`.tool-versions` サポート）を満たす唯一のツール
+  - 要件 4（グループ化）の組み込みサポート
+  - 要件 5（自動マージ）の柔軟な設定
+  - Dependabot との併用は複雑さが増すだけでメリットなし
+- **Trade-offs**:
+  - ✅ 全要件を単一ツールで実現
+  - ✅ 設定ファイルでの一元管理
+  - ⚠️ Dependabot より初期設定が複雑
+  - ⚠️ 外部サービス（Mend）への依存
+- **Follow-up**: GitHub App のインストールとリポジトリアクセス許可の確認
+
+### Decision: 設定ファイルの配置場所
+
+- **Context**: Renovate 設定ファイルの配置場所
+- **Alternatives Considered**:
+  1. `renovate.json` — ルートディレクトリ
+  2. `.github/renovate.json` — GitHub 設定と統合
+  3. `package.json` の `renovate` キー — 既存ファイル利用
+- **Selected Approach**: `renovate.json` をルートディレクトリに配置
+- **Rationale**:
+  - 最も一般的で発見しやすい場所
+  - Renovate のデフォルト検索パス
+  - 独立したファイルで管理が容易
+- **Trade-offs**:
+  - ✅ 標準的な配置
+  - ✅ 他の設定と分離
+  - ⚠️ ルートディレクトリのファイル数が増加
+
+## Risks & Mitigations
+
+- **Renovate GitHub App の可用性** — Mend のサービス障害時はアップデートが停止。許容可能なリスク（クリティカルな機能ではない）
+- **過剰な PR 作成** — 週次スケジュールとグループ化で軽減
+- **自動マージによる破壊的変更** — devDependencies のパッチのみに限定、CI テスト通過必須
+- **Branch protection rules との競合** — Renovate を bypass 対象に追加する必要あり
+
+## References
+
+- [Renovate Documentation](https://docs.renovatebot.com/) — 公式ドキュメント
+- [Renovate Bot Comparison](https://docs.renovatebot.com/bot-comparison/) — Dependabot との比較
+- [Renovate asdf Manager](https://docs.renovatebot.com/modules/manager/asdf/) — `.tool-versions` サポート
+- [Renovate Automerge](https://docs.renovatebot.com/key-concepts/automerge/) — 自動マージ設定
+- [Renovate Configuration Options](https://docs.renovatebot.com/configuration-options/) — 設定リファレンス
+- [GitHub Issue: Dependabot asdf support](https://github.com/dependabot/dependabot-core/issues/1033) — Dependabot の `.tool-versions` 非対応

--- a/.kiro/specs/automated-dependency-updates/spec.json
+++ b/.kiro/specs/automated-dependency-updates/spec.json
@@ -1,0 +1,22 @@
+{
+  "feature_name": "automated-dependency-updates",
+  "created_at": "2026-01-16T00:00:00Z",
+  "updated_at": "2026-01-16T00:00:00Z",
+  "language": "ja",
+  "phase": "tasks-generated",
+  "approvals": {
+    "requirements": {
+      "generated": true,
+      "approved": true
+    },
+    "design": {
+      "generated": true,
+      "approved": true
+    },
+    "tasks": {
+      "generated": true,
+      "approved": true
+    }
+  },
+  "ready_for_implementation": true
+}

--- a/.kiro/specs/automated-dependency-updates/tasks.md
+++ b/.kiro/specs/automated-dependency-updates/tasks.md
@@ -1,0 +1,139 @@
+# Implementation Plan
+
+## Overview
+
+本実装計画は、Renovate GitHub App を使用した依存関係自動アップデート機能の導入手順を定義する。
+アプリケーションコードの変更は不要で、設定ファイルの追加と GitHub App のインストールのみで完結する。
+
+**ユーザー作業と AI 実装作業の区分**:
+
+- **🔧 AI 実装**: 設定ファイルの作成（自動化可能）
+- **👤 ユーザー作業**: GitHub App のインストールと権限設定（手動操作必須）
+
+---
+
+## Tasks
+
+- [x] 1. Renovate 設定ファイルの作成
+- [x] 1.1 基本設定とスケジュールの定義
+  - リポジトリルートに `renovate.json` を作成
+  - JSON Schema 参照を設定して IDE での検証を有効化
+  - 推奨プリセット `config:recommended` を継承
+  - タイムゾーンを `Asia/Tokyo` に設定
+  - 週次スケジュール（毎週月曜日の午前9時前）を設定
+  - PR 作成制限（時間あたり5件、同時最大10件）を設定
+  - npm と asdf マネージャーを有効化
+  - Dependency Dashboard を無効化（ノイズ軽減）
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 3.1, 3.3, 7.1_
+
+- [x] 1.2 パッケージグループ化ルールの設定
+  - AWS Amplify パッケージ（`@aws-amplify/*`, `aws-amplify`）のグループ化
+  - TanStack パッケージ（`@tanstack/*`）のグループ化
+  - Mantine パッケージ（`@mantine/*`）のグループ化
+  - テスト関連パッケージ（`@testing-library/*`, `vitest`, `@vitest/*`）のグループ化
+  - 型定義パッケージ（`@types/*`）のグループ化
+  - devDependencies のマイナーアップデートをグループ化
+  - _Requirements: 4.1, 4.2_
+
+- [x] 1.3 自動マージとセキュリティ設定
+  - devDependencies のパッチアップデートに対する自動マージを有効化
+  - 自動マージ戦略として squash マージを設定
+  - セキュリティアラートを常時有効化（スケジュール外でも即時対応）
+  - dependencies（本番依存）は自動マージ対象外とする
+  - _Requirements: 3.2, 5.1, 5.2, 5.3, 5.4_
+
+- [x] 1.4 Node.js バージョン管理の設定
+  - asdf マネージャーで Node.js パッケージを個別に管理
+  - メジャー/マイナーバージョンを分離して PR 作成
+  - Node.js アップデートは自動マージ対象外とする
+  - _Requirements: 7.1, 7.2, 7.3_
+
+- [ ] 2. 👤 Renovate GitHub App のインストール（ユーザー作業）
+  - GitHub Marketplace（https://github.com/apps/renovate）にアクセス
+  - 「Install」または「Configure」をクリック
+  - 対象リポジトリ（aws-s3-photo-browser）を選択してアクセス許可
+  - インストール完了後、Renovate が自動的に Onboarding PR を作成することを確認
+  - **注意**: この作業は GitHub の Web UI で手動実行が必要
+  - _Requirements: 1.1, 1.3, 2.1_
+
+- [ ] 3. 動作確認と検証
+- [ ] 3.1 設定ファイルの検証
+  - `renovate.json` の JSON 構文を検証
+  - JSON Schema に基づく設定の妥当性を確認
+  - 設定ファイルをコミットして PR を作成
+  - _Requirements: 1.2_
+
+- [ ] 3.2 👤 初回スキャンと PR 確認（ユーザー作業）
+  - Renovate App インストール後の Onboarding PR を確認
+  - Onboarding PR をマージして Renovate を有効化
+  - 初回スキャン後に作成される依存関係更新 PR を確認
+  - PR にパッケージ名、バージョン情報、changelog リンクが含まれることを確認
+  - CI ワークフロー（`npm run check-all`）が自動トリガーされることを確認
+  - **注意**: この作業は GitHub の Web UI で確認が必要
+  - _Requirements: 2.1, 2.2, 2.3, 2.4_
+
+- [ ] 3.3 👤 自動マージ動作の検証（ユーザー作業・オプション）
+  - devDependencies のパッチアップデート PR が作成されるまで待機
+  - CI 成功後に自動マージが実行されることを確認
+  - 自動マージが実行されない場合は Branch Protection Rules を確認
+  - 必要に応じて Renovate を bypass 対象に追加
+  - **注意**: 実際のパッチアップデートが発生するまで時間がかかる可能性あり
+  - _Requirements: 5.1, 5.2, 5.3, 5.4_
+
+---
+
+## Requirements Coverage
+
+| Requirement | Tasks                                    |
+| ----------- | ---------------------------------------- |
+| 1.1         | 1.1, 2                                   |
+| 1.2         | 1.1, 3.1                                 |
+| 1.3         | 1.1, 2                                   |
+| 1.4         | 1.1                                      |
+| 2.1         | 2, 3.2                                   |
+| 2.2         | 3.2                                      |
+| 2.3         | 3.2                                      |
+| 2.4         | 3.2                                      |
+| 3.1         | 1.1                                      |
+| 3.2         | 1.3                                      |
+| 3.3         | 1.1                                      |
+| 4.1         | 1.2                                      |
+| 4.2         | 1.2                                      |
+| 4.3         | （Renovate デフォルト動作で対応）        |
+| 5.1         | 1.3, 3.3                                 |
+| 5.2         | 1.3, 3.3                                 |
+| 5.3         | 1.3, 3.3                                 |
+| 5.4         | 1.3, 3.3                                 |
+| 6.1         | （設定で対応可能、初期設定では除外なし） |
+| 6.2         | （設定で対応可能、初期設定では固定なし） |
+| 6.3         | （Renovate が自動検出）                  |
+| 7.1         | 1.1, 1.4                                 |
+| 7.2         | 1.4                                      |
+| 7.3         | 1.4                                      |
+
+---
+
+## Notes
+
+### ユーザー作業が必要な理由
+
+以下の作業は GitHub の Web UI または API トークンを使用した操作が必要なため、ユーザーによる手動実行が必須です：
+
+1. **Renovate GitHub App のインストール**: GitHub Marketplace からのアプリインストールはリポジトリオーナーの権限が必要
+2. **Onboarding PR の確認とマージ**: PR のマージ操作はユーザーの承認が必要
+3. **Branch Protection Rules の調整**: リポジトリ設定の変更はユーザーの権限が必要
+
+### 除外設定について（要件 6）
+
+初期設定では特定パッケージの除外は行わない。将来的に互換性問題が発生した場合、以下のような `packageRules` を追加することで対応可能：
+
+```json
+{
+  "matchPackageNames": ["problematic-package"],
+  "enabled": false
+}
+```
+
+### メジャーアップデートについて（要件 4.3）
+
+Renovate のデフォルト動作でメジャーアップデートは個別の PR として作成されるため、明示的な設定は不要。

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":disableDependencyDashboard"],
+  "timezone": "Asia/Tokyo",
+  "schedule": ["before 9am on monday"],
+  "prHourlyLimit": 5,
+  "prConcurrentLimit": 10,
+  "enabledManagers": ["npm", "asdf"],
+  "packageRules": [
+    {
+      "description": "AWS Amplify packages",
+      "matchPackagePatterns": ["^@aws-amplify/", "^aws-amplify$"],
+      "groupName": "aws-amplify"
+    },
+    {
+      "description": "TanStack packages",
+      "matchPackagePatterns": ["^@tanstack/"],
+      "groupName": "tanstack"
+    },
+    {
+      "description": "Mantine packages",
+      "matchPackagePatterns": ["^@mantine/"],
+      "groupName": "mantine"
+    },
+    {
+      "description": "Testing packages",
+      "matchPackagePatterns": ["^@testing-library/", "^vitest$", "^@vitest/"],
+      "groupName": "testing"
+    },
+    {
+      "description": "Type definitions",
+      "matchPackagePatterns": ["^@types/"],
+      "groupName": "types"
+    },
+    {
+      "description": "Automerge devDependencies patch updates",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch"],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "squash"
+    },
+    {
+      "description": "Group devDependencies minor updates",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor"],
+      "groupName": "devDependencies-minor"
+    },
+    {
+      "description": "Node.js updates as separate PRs",
+      "matchManagers": ["asdf"],
+      "matchPackageNames": ["node"],
+      "separateMajorMinor": true,
+      "automerge": false
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "schedule": ["at any time"]
+  }
+}


### PR DESCRIPTION
- renovate.json を追加
- 週次スケジュール（毎週月曜 9:00 前）でアップデートチェック
- パッケージグループ化: aws-amplify, tanstack, mantine, testing, types
- devDependencies パッチのみ自動マージ（squash）
- Node.js (.tool-versions) のバージョン管理を有効化
- セキュリティアラートは即時対応