### PR TITLE
ci: GitHub Actions で Renovate を self-hosted 実行

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,20 @@
+name: Renovate
+
+on:
+  # 毎週月曜 9:00 JST (0:00 UTC) に実行
+  schedule:
+    - cron: "0 0 * * 1"
+  # 手動実行
+  workflow_dispatch:
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: renovatebot/github-action@v44
+        with:
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          LOG_LEVEL: info


### PR DESCRIPTION
Mend Renovate App (GitHub App) では Onboarding PR が作成されないため、 GitHub Actions で renovatebot/github-action を使用した self-hosted 方式に変更。

- 毎週月曜 9:00 JST にスケジュール実行
- workflow_dispatch で手動実行も可能
- RENOVATE_TOKEN (PAT) で認証