### PR TITLE
fix(ci): renovatebot/github-action のバージョンを修正

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: renovatebot/github-action@v44
+      - uses: renovatebot/github-action@v44.2.4
         with:
           token: ${{ secrets.RENOVATE_TOKEN }}
         env:


### PR DESCRIPTION
v44 タグが存在しないため v44.2.4 に変更