### PR TITLE
fix: MoveDialog の flaky test を根本解決

### DIFF
--- a/src/components/MediaBrowser/FileList.test.tsx
+++ b/src/components/MediaBrowser/FileList.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import { MantineProvider } from "@mantine/core";
 import { FileList } from "./FileList";
 import type { StorageItem } from "../../types/storage";
@@ -511,7 +511,9 @@ describe("FileList", () => {
       fireEvent.mouseDown(folderItem);
 
       // 400ms 経過をシミュレート（長押し完了）
-      vi.advanceTimersByTime(400);
+      act(() => {
+        vi.advanceTimersByTime(400);
+      });
 
       // マウスアップでクリックイベントが発生
       fireEvent.mouseUp(folderItem);
@@ -543,7 +545,9 @@ describe("FileList", () => {
 
       // 短いタップ（100ms）
       fireEvent.mouseDown(folderItem);
-      vi.advanceTimersByTime(100);
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
       fireEvent.mouseUp(folderItem);
       fireEvent.click(folderItem);
 
@@ -576,7 +580,9 @@ describe("FileList", () => {
 
       // 長押し（400ms）
       fireEvent.mouseDown(folderItem);
-      vi.advanceTimersByTime(400);
+      act(() => {
+        vi.advanceTimersByTime(400);
+      });
       fireEvent.mouseUp(folderItem);
       fireEvent.click(folderItem);
 

--- a/src/components/MediaBrowser/MoveDialog.test.tsx
+++ b/src/components/MediaBrowser/MoveDialog.test.tsx
@@ -648,12 +648,7 @@ describe("MoveDialog", () => {
         fireEvent.click(overlay);
       }
 
-      // イベント処理が完了するまで少し待つ（非同期イベントハンドラの完了を待つ）
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
-
-      // 移動中はクローズが呼ばれない
+      // 移動中はクローズが呼ばれない（handleClose 内でガードされる）
       expect(mockOnClose).not.toHaveBeenCalled();
 
       // テスト終了前に移動を完了させる

--- a/src/components/MediaBrowser/MoveDialog.tsx
+++ b/src/components/MediaBrowser/MoveDialog.tsx
@@ -53,6 +53,13 @@ export function MoveDialog({
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [failedItems, setFailedItems] = useState<string[]>([]);
 
+  // ガード付きの onClose ハンドラ
+  // closeOnClickOutside の反映タイミングに依存せず、確実に移動中のクローズを防ぐ
+  const handleClose = useCallback(() => {
+    if (isMoving) return;
+    onClose();
+  }, [isMoving, onClose]);
+
   // 無効化するパス（循環移動防止）
   const disabledPaths = useMemo(() => {
     const paths: string[] = [];
@@ -162,7 +169,7 @@ export function MoveDialog({
   return (
     <Modal
       opened={isOpen}
-      onClose={onClose}
+      onClose={handleClose}
       title={`${itemCount}件のアイテムを移動`}
       size="lg"
       centered
@@ -219,7 +226,7 @@ export function MoveDialog({
 
         {/* アクションボタン */}
         <Group justify="flex-end" gap="sm">
-          <Button variant="default" onClick={onClose} disabled={isMoving}>
+          <Button variant="default" onClick={handleClose} disabled={isMoving}>
             キャンセル
           </Button>
           <Button onClick={handleMove} loading={isMoving} disabled={!canMove && !isMoving}>

--- a/src/hooks/storage/useStorageOperations.test.ts
+++ b/src/hooks/storage/useStorageOperations.test.ts
@@ -480,13 +480,10 @@ describe("useStorageOperations", () => {
         deletePromise = result.current.removeItems(items);
       });
 
-      // Wait a tick for mutation to start
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
-
       // isDeleting should be true while deletion is in progress
-      expect(result.current.isDeleting).toBe(true);
+      await waitFor(() => {
+        expect(result.current.isDeleting).toBe(true);
+      });
 
       await act(async () => {
         resolveRemove!();
@@ -693,12 +690,10 @@ describe("useStorageOperations", () => {
         renamePromise = result.current.renameItem(`${basePath}old.jpg`, "new.jpg");
       });
 
-      // Wait for mutation to start
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
+      // isRenaming should be true while rename is in progress
+      await waitFor(() => {
+        expect(result.current.isRenaming).toBe(true);
       });
-
-      expect(result.current.isRenaming).toBe(true);
 
       await act(async () => {
         resolveCopy!({ path: `${basePath}new.jpg` });
@@ -980,12 +975,10 @@ describe("useStorageOperations", () => {
         renamePromise = result.current.renameFolder(`${basePath}old/`, "new");
       });
 
-      // Wait a tick for the async operation to start
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
+      // isRenaming should be true while folder rename is in progress
+      await waitFor(() => {
+        expect(result.current.isRenaming).toBe(true);
       });
-
-      expect(result.current.isRenaming).toBe(true);
 
       await act(async () => {
         resolveCopy!({ path: "test" });
@@ -1250,12 +1243,10 @@ describe("useStorageOperations", () => {
         movePromise = result.current.moveItems(items, `${basePath}archive`);
       });
 
-      // Wait a tick for the async operation to start
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 0));
+      // isMoving should be true while move is in progress
+      await waitFor(() => {
+        expect(result.current.isMoving).toBe(true);
       });
-
-      expect(result.current.isMoving).toBe(true);
 
       await act(async () => {
         resolveCopy!({ path: "test" });


### PR DESCRIPTION
問題:
- Mantine Modal の closeOnClickOutside プロパティは React の状態更新と Modal 内部のイベントハンドラの同期にタイミングラグがある
- isMoving=true になっても、オーバーレイクリック時に onClose が 呼ばれる競合状態が発生していた

解決策:
- MoveDialog に handleClose ガード付きハンドラを追加
- closeOnClickOutside の内部実装に依存せず、isMoving 状態を明示的にチェック
- テストコードから場当たり的な setTimeout(resolve, 0) を削除
- useStorageOperations.test.ts の setTimeout も waitFor に置換して堅牢化