### PR TITLE
feat: Lightbox のプレビューを遅延読み込みし、アップロード上限を100に拡大

### DIFF
--- a/src/components/MediaBrowser/FileActions.tsx
+++ b/src/components/MediaBrowser/FileActions.tsx
@@ -117,7 +117,7 @@ export function FileActions({
             <FileUploader
               acceptedFileTypes={["image/*", "video/*"]}
               path={getUploadPath()}
-              maxFileCount={10}
+              maxFileCount={100}
               isResumable
               processFile={processFile}
               onUploadSuccess={handleUploadSuccess}

--- a/src/components/MediaBrowser/PreviewModal.test.tsx
+++ b/src/components/MediaBrowser/PreviewModal.test.tsx
@@ -34,7 +34,7 @@ let capturedProps: {
   index?: number;
   slides?: unknown[];
   controller?: { closeOnPullDown?: boolean };
-  carousel?: { finite?: boolean };
+  carousel?: { finite?: boolean; preload?: number };
   on?: { view?: (data: { index: number }) => void };
 } = {};
 
@@ -47,7 +47,7 @@ vi.mock("yet-another-react-lightbox", () => ({
     index?: number;
     slides?: unknown[];
     controller?: { closeOnPullDown?: boolean };
-    carousel?: { finite?: boolean };
+    carousel?: { finite?: boolean; preload?: number };
     on?: { view?: (data: { index: number }) => void };
   }) => {
     capturedProps = {
@@ -364,7 +364,11 @@ describe("PreviewModal", () => {
         { wrapper: TestProvider },
       );
 
-      expect(mockUsePreviewUrls).toHaveBeenCalledWith(items, { enabled: true });
+      expect(mockUsePreviewUrls).toHaveBeenCalledWith(items, {
+        enabled: true,
+        currentIndex: 0,
+        preload: 1,
+      });
     });
 
     it("should call usePreviewUrls with enabled: false when isOpen is false", () => {
@@ -381,7 +385,11 @@ describe("PreviewModal", () => {
         { wrapper: TestProvider },
       );
 
-      expect(mockUsePreviewUrls).toHaveBeenCalledWith(items, { enabled: false });
+      expect(mockUsePreviewUrls).toHaveBeenCalledWith(items, {
+        enabled: false,
+        currentIndex: 0,
+        preload: 1,
+      });
     });
 
     it("should show loading state when isLoading is true", () => {

--- a/src/components/MediaBrowser/PreviewModal.tsx
+++ b/src/components/MediaBrowser/PreviewModal.tsx
@@ -58,7 +58,12 @@ export function PreviewModal(props: PreviewModalProps) {
   const currentItem = items[currentIndex] ?? null;
 
   // usePreviewUrls フックで署名付き URL を取得
-  const { data: slides, isLoading: loading } = usePreviewUrls(items, { enabled: isOpen });
+  // Lightbox 表示時のみ署名付き URL を取得（現スライドの前後1枚を先読み）
+  const { data: slides, isLoading: loading } = usePreviewUrls(items, {
+    enabled: isOpen,
+    currentIndex,
+    preload: 1,
+  });
 
   // 削除ボタンクリック時: Jotai atoms を通じて DeleteConfirmDialog を表示させる
   const handleDeleteClick = () => {
@@ -107,6 +112,8 @@ export function PreviewModal(props: PreviewModalProps) {
           autoPlay: true,
           controls: true,
           playsInline: true,
+          // 動画は開いた瞬間に読み込ませない（必要になったタイミングで取得）
+          preload: "none",
         }}
         zoom={{
           maxZoomPixelRatio: 3,
@@ -114,6 +121,8 @@ export function PreviewModal(props: PreviewModalProps) {
         }}
         carousel={{
           finite: true,
+          // Lightbox 内のスライド先読み枚数（hooks と合わせる）
+          preload: 1,
         }}
         styles={{
           container: {

--- a/src/hooks/storage/usePreviewUrls.ts
+++ b/src/hooks/storage/usePreviewUrls.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQueries } from "@tanstack/react-query";
 import { getUrl } from "aws-amplify/storage";
 import type { Slide } from "yet-another-react-lightbox";
 import type { StorageItem } from "../../types/storage";
@@ -24,12 +24,12 @@ function getVideoMimeType(filename: string): string {
 /**
  * StorageItem から Slide を生成する
  */
-async function createSlide(item: StorageItem): Promise<Slide | null> {
-  const { url } = await getUrl({ path: item.key });
-  const urlString = url.toString();
+// 未取得のスライド用に使う 1px 透明画像（ネットワーク負荷なし）
+const TRANSPARENT_PIXEL = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==";
 
+function createSlide(item: StorageItem, urlString?: string): Slide | null {
   if (isImageFile(item.name)) {
-    return { src: urlString };
+    return { src: urlString ?? TRANSPARENT_PIXEL };
   }
 
   if (isVideoFile(item.name)) {
@@ -37,7 +37,7 @@ async function createSlide(item: StorageItem): Promise<Slide | null> {
       type: "video" as const,
       width: 1280,
       height: 720,
-      sources: [{ src: urlString, type: getVideoMimeType(item.name) }],
+      sources: urlString ? [{ src: urlString, type: getVideoMimeType(item.name) }] : [],
     };
   }
 
@@ -46,6 +46,10 @@ async function createSlide(item: StorageItem): Promise<Slide | null> {
 
 export interface UsePreviewUrlsOptions {
   enabled?: boolean;
+  /** 現在表示中のスライド位置（lazy の基準） */
+  currentIndex?: number;
+  /** 前後に先読みする枚数 */
+  preload?: number;
 }
 
 export interface UsePreviewUrlsResult extends QueryReturn<Slide[]> {}
@@ -61,28 +65,56 @@ export function usePreviewUrls(
   items: StorageItem[],
   options: UsePreviewUrlsOptions = {},
 ): UsePreviewUrlsResult {
-  const { enabled = true } = options;
+  const { enabled = true, currentIndex, preload = 1 } = options;
 
-  const itemKeys = items.map((item) => item.key);
   const hasItems = items.length > 0;
+  // currentIndex がある場合のみ lazy 対象にする
+  const shouldLazyLoad = Number.isFinite(currentIndex);
+  const safePreload = Math.max(0, preload);
+  // 現在位置から前後 safePreload 枚を取得対象にする
+  const loadStart = shouldLazyLoad ? Math.max(0, (currentIndex ?? 0) - safePreload) : 0;
+  const loadEnd = shouldLazyLoad
+    ? Math.min(items.length - 1, (currentIndex ?? 0) + safePreload)
+    : items.length - 1;
 
-  const { data, isLoading, isError, error } = useQuery({
-    queryKey: queryKeys.previewUrls(itemKeys),
-    queryFn: async () => {
-      const slidePromises = items.map(createSlide);
-      const results = await Promise.all(slidePromises);
-      return results.filter((slide): slide is Slide => slide !== null);
-    },
-    enabled: enabled && hasItems,
-    staleTime: 10 * 60 * 1000, // 10分（署名付き URL の有効期限を考慮）
+  // URL 取得をアイテム単位の query に分割（lazy で必要分だけ取得）
+  const results = useQueries({
+    queries: items.map((item, index) => {
+      const previewable = isImageFile(item.name) || isVideoFile(item.name);
+      const inRange = index >= loadStart && index <= loadEnd;
+      const shouldFetch = enabled && hasItems && previewable && (!shouldLazyLoad || inRange);
+      return {
+        queryKey: queryKeys.previewUrl(item.key),
+        queryFn: async () => {
+          const { url } = await getUrl({ path: item.key });
+          return createSlide(item, url.toString());
+        },
+        enabled: shouldFetch,
+        staleTime: 10 * 60 * 1000, // 10分（署名付き URL の有効期限を考慮）
+      };
+    }),
   });
 
-  const slides = data ?? [];
+  // URL 未取得のスライドはプレースホルダにする
+  const slides = items
+    .map((item, index) => {
+      const previewable = isImageFile(item.name) || isVideoFile(item.name);
+      if (!previewable) return null;
+      const data = results[index]?.data;
+      return data ?? createSlide(item);
+    })
+    .filter((slide): slide is Slide => slide !== null);
+
+  const shouldReturnEmpty = !hasItems || !enabled;
+  // 1枚も取得できていない場合は Lightbox を開かない
+  const hasLoadedSlide = results.some((result) => Boolean(result.data));
 
   return {
-    data: slides,
-    isLoading: hasItems && enabled ? isLoading : false,
-    isError,
-    error: error as Error | null,
+    data: shouldReturnEmpty || !hasLoadedSlide ? [] : slides,
+    isLoading: shouldReturnEmpty ? false : results.some((result) => result.isLoading),
+    isError: shouldReturnEmpty ? false : results.some((result) => result.isError),
+    error: shouldReturnEmpty
+      ? null
+      : (results.find((result) => result.isError)?.error as Error | null),
   };
 }

--- a/src/stores/queryKeys.ts
+++ b/src/stores/queryKeys.ts
@@ -13,6 +13,12 @@ export const queryKeys = {
   identityId: () => ["identityId"] as const,
 
   /**
+   * プレビュー URL の queryKey（単一）
+   * @example queryKeys.previewUrl("photo1.jpg") // ["previewUrl", "photo1.jpg"]
+   */
+  previewUrl: (itemKey: string) => ["previewUrl", itemKey] as const,
+
+  /**
    * プレビュー URL の queryKey
    * @example queryKeys.previewUrls(["photo1.jpg", "photo2.jpg"]) // ["previewUrls", "photo1.jpg", "photo2.jpg"]
    */


### PR DESCRIPTION
Lightbox のプレビューURL取得を全件一括から「現在スライド＋前後1枚」に変更。
currentIndex と preload を用いて取得範囲を決定し、useQueries でアイテム単位に分割取得。 未取得スライドはプレースホルダを返して Lightbox を開きつつ、必要分だけURL取得するようにした。 1枚も取得できていない状態では Lightbox を開かないガードも追加。
動画は preload="none" にして不要な先読みを抑制し、Lightbox の carousel preload も1に合わせた。

FileUploader の maxFileCount を 10 → 100 に拡大。