### PR TITLE
feat: 既存の動画サムネイルを作り直すスクリプトを追加

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+ignore-scripts=true

--- a/amplify/functions/thumbnail/handler.ts
+++ b/amplify/functions/thumbnail/handler.ts
@@ -1,4 +1,3 @@
-import type { S3Handler, S3Event } from "aws-lambda";
 import {
   S3Client,
   GetObjectCommand,
@@ -11,6 +10,7 @@ import { writeFile, readFile, unlink, access, stat } from "fs/promises";
 import { constants } from "fs";
 import { join } from "path";
 import { type Command, type CommandOutput, extractFrame, type FrameTools } from "./frame";
+import { isRegenerate, requestsOf, type ThumbnailEvent } from "./requests";
 import { isImageFile, isVideoFile, getThumbnailPath } from "./utils";
 
 /**
@@ -46,12 +46,12 @@ const THUMBNAIL_CONFIG = {
 /**
  * S3 Event Handler for thumbnail generation and deletion
  */
-export const handler: S3Handler = async (event: S3Event): Promise<void> => {
-  for (const record of event.Records) {
-    const eventName = record.eventName;
-    const bucket = record.s3.bucket.name;
-    const key = decodeURIComponent(record.s3.object.key.replace(/\+/g, " "));
+export const handler = async (event: ThumbnailEvent): Promise<void> => {
+  // A direct invocation is a manual operation on a single object, so its
+  // failure has to reach the caller instead of ending up in the log only
+  const direct = isRegenerate(event);
 
+  for (const { eventName, bucket, key } of requestsOf(event)) {
     console.log(`Processing event: ${eventName} for ${key}`);
 
     // Only process files in media/ prefix
@@ -69,6 +69,9 @@ export const handler: S3Handler = async (event: S3Event): Promise<void> => {
     } catch (error) {
       // Log error but don't throw - allow other records to process
       console.error(`Error processing ${key}:`, error);
+      if (direct) {
+        throw error;
+      }
     }
   }
 };

--- a/amplify/functions/thumbnail/requests.test.ts
+++ b/amplify/functions/thumbnail/requests.test.ts
@@ -1,0 +1,49 @@
+import type { S3Event } from "aws-lambda";
+import { describe, expect, it } from "vitest";
+import { isRegenerate, requestsOf } from "./requests";
+
+const BUCKET = "media-bucket";
+
+function notification(...keys: string[]): S3Event {
+  return {
+    Records: keys.map((key) => ({
+      eventName: "ObjectCreated:Put",
+      s3: { bucket: { name: BUCKET }, object: { key } },
+    })),
+  } as S3Event;
+}
+
+describe("thumbnail requests", () => {
+  describe("requestsOf", () => {
+    it("should take every object out of a notification", () => {
+      expect(requestsOf(notification("media/abc/one.mp4", "media/abc/two.jpg"))).toEqual([
+        { eventName: "ObjectCreated:Put", bucket: BUCKET, key: "media/abc/one.mp4" },
+        { eventName: "ObjectCreated:Put", bucket: BUCKET, key: "media/abc/two.jpg" },
+      ]);
+    });
+
+    it("should decode the key of a notification", () => {
+      // S3 encodes the key, and these keys are the file names people chose
+      expect(requestsOf(notification("media/abc/my+holiday+clip%281%29.mp4"))[0].key).toBe(
+        "media/abc/my holiday clip(1).mp4",
+      );
+    });
+
+    it("should take the key of a direct invocation as-is", () => {
+      expect(requestsOf({ bucket: BUCKET, key: "media/abc/my holiday clip(1).mp4" })).toEqual([
+        {
+          eventName: "ObjectCreated:Regenerate",
+          bucket: BUCKET,
+          key: "media/abc/my holiday clip(1).mp4",
+        },
+      ]);
+    });
+  });
+
+  describe("isRegenerate", () => {
+    it("should tell a direct invocation from a notification", () => {
+      expect(isRegenerate({ bucket: BUCKET, key: "media/abc/one.mp4" })).toBe(true);
+      expect(isRegenerate(notification("media/abc/one.mp4"))).toBe(false);
+    });
+  });
+});

--- a/amplify/functions/thumbnail/requests.ts
+++ b/amplify/functions/thumbnail/requests.ts
@@ -1,0 +1,36 @@
+import type { S3Event } from "aws-lambda";
+
+/**
+ * Direct invocation for rebuilding the thumbnail of an object that is already
+ * stored (see scripts/regenerate-thumbnails.ts).
+ *
+ * S3 notifications URL-encode the object key, and keys here contain the file
+ * names people chose, so a hand-built notification would mangle names with
+ * spaces. Taking the key as-is avoids that encoding entirely.
+ */
+export type RegenerateEvent = { bucket: string; key: string };
+
+export type ThumbnailEvent = S3Event | RegenerateEvent;
+
+export type ThumbnailRequest = { eventName: string; bucket: string; key: string };
+
+/** Whether the event came from a direct invocation rather than a notification */
+export function isRegenerate(event: ThumbnailEvent): event is RegenerateEvent {
+  return !("Records" in event);
+}
+
+/**
+ * Normalize both entry points into the same list of objects to process.
+ */
+export function requestsOf(event: ThumbnailEvent): ThumbnailRequest[] {
+  if (isRegenerate(event)) {
+    // Rebuilding always replaces the thumbnail, so treat it as an upload
+    return [{ eventName: "ObjectCreated:Regenerate", bucket: event.bucket, key: event.key }];
+  }
+
+  return event.Records.map((record) => ({
+    eventName: record.eventName,
+    bucket: record.s3.bucket.name,
+    key: decodeURIComponent(record.s3.object.key.replace(/\+/g, " ")),
+  }));
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
       "devDependencies": {
         "@aws-amplify/backend": "^1.19.0",
         "@aws-amplify/backend-cli": "^1.8.1",
+        "@aws-sdk/client-lambda": "^3.1096.0",
         "@aws-sdk/client-s3": "^3.962.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.1",
@@ -21744,72 +21745,273 @@
       }
     },
     "node_modules/@aws-sdk/client-lambda": {
-      "version": "3.958.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.958.0.tgz",
-      "integrity": "sha512-gwEqpDkgPLbFfewQkRRgnqn9iCfnd5BUVFUZpUoyq8DxzPmNn/lEVMkBaNCqwIXx07jd46+qd1neWBrH2UYi2Q==",
+      "version": "3.1096.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1096.0.tgz",
+      "integrity": "sha512-IZFJ+PWddzjYXRcSVStN5XYE2BrlbZvY12gt/skragYHklm1hvv2BRfeBvDgh7WCvBuS+2ucCS/jFF/IGVsUvg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.957.0",
-        "@aws-sdk/credential-provider-node": "3.958.0",
-        "@aws-sdk/middleware-host-header": "3.957.0",
-        "@aws-sdk/middleware-logger": "3.957.0",
-        "@aws-sdk/middleware-recursion-detection": "3.957.0",
-        "@aws-sdk/middleware-user-agent": "3.957.0",
-        "@aws-sdk/region-config-resolver": "3.957.0",
-        "@aws-sdk/types": "3.957.0",
-        "@aws-sdk/util-endpoints": "3.957.0",
-        "@aws-sdk/util-user-agent-browser": "3.957.0",
-        "@aws-sdk/util-user-agent-node": "3.957.0",
-        "@smithy/config-resolver": "^4.4.5",
-        "@smithy/core": "^3.20.0",
-        "@smithy/eventstream-serde-browser": "^4.2.7",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.7",
-        "@smithy/eventstream-serde-node": "^4.2.7",
-        "@smithy/fetch-http-handler": "^5.3.8",
-        "@smithy/hash-node": "^4.2.7",
-        "@smithy/invalid-dependency": "^4.2.7",
-        "@smithy/middleware-content-length": "^4.2.7",
-        "@smithy/middleware-endpoint": "^4.4.1",
-        "@smithy/middleware-retry": "^4.4.17",
-        "@smithy/middleware-serde": "^4.2.8",
-        "@smithy/middleware-stack": "^4.2.7",
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/node-http-handler": "^4.4.7",
-        "@smithy/protocol-http": "^5.3.7",
-        "@smithy/smithy-client": "^4.10.2",
-        "@smithy/types": "^4.11.0",
-        "@smithy/url-parser": "^4.2.7",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.16",
-        "@smithy/util-defaults-mode-node": "^4.2.19",
-        "@smithy/util-endpoints": "^3.2.7",
-        "@smithy/util-middleware": "^4.2.7",
-        "@smithy/util-retry": "^4.2.7",
-        "@smithy/util-stream": "^4.5.8",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/util-waiter": "^4.2.7",
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/credential-provider-node": "^3.972.73",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-lambda/node_modules/@smithy/util-base64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
-      "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/core": {
+      "version": "3.977.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.1.tgz",
+      "integrity": "sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.37",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.8",
+        "@smithy/signature-v4": "^5.6.9",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.62",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.62.tgz",
+      "integrity": "sha512-BkDrk2cNjed31IKin/Oksb2ziF+gfuyRskFVuT4EU9Mep7M8Y/d8DJG4+anHme4Vuse7CwaEscwEfGyR6mzBhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.64",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.64.tgz",
+      "integrity": "sha512-Wj1FGK2IxY5EccQCvH+niTYhIvDoDujJf2CpRRgS3NpYNEgiFNVItNbJYQjINRlu7fG7jSsXkKV0UWKriEplrw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.7.tgz",
+      "integrity": "sha512-2CefB8cCxDu52P24B8Ay93/cTT199bcSvNHQ8e2f4BjSCF83yErBnTIZEBo0VeIgCfmw+PJKFUXnlQWxm2dkug==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/credential-provider-env": "^3.972.62",
+        "@aws-sdk/credential-provider-http": "^3.972.64",
+        "@aws-sdk/credential-provider-login": "^3.972.69",
+        "@aws-sdk/credential-provider-process": "^3.972.62",
+        "@aws-sdk/credential-provider-sso": "^3.973.6",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.68",
+        "@aws-sdk/nested-clients": "^3.997.36",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/credential-provider-imds": "^4.4.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.69.tgz",
+      "integrity": "sha512-gM3j0Ie9+FoLNTYODY+QWbg3vCRBc7mR9cRdntxTMkFYIrwfRmuucfavP6HNBlYSuaYww54TNJGej4GFgoPZAg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/nested-clients": "^3.997.36",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.73",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.73.tgz",
+      "integrity": "sha512-VTzdbf8Ukjdb9yUubZzRI678CWZvKovhE8Nv3qihwhC187sRMGls+r9N8Wuht5q1xjKx2nmpS48ar8ppupjkCA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.62",
+        "@aws-sdk/credential-provider-http": "^3.972.64",
+        "@aws-sdk/credential-provider-ini": "^3.973.7",
+        "@aws-sdk/credential-provider-process": "^3.972.62",
+        "@aws-sdk/credential-provider-sso": "^3.973.6",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.68",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/credential-provider-imds": "^4.4.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.62",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.62.tgz",
+      "integrity": "sha512-zXYU9UWNL66gtMgNLhmxlrvEokuI7r6G2q7FRGu41Bya4iS30JLelUipJX9SV4zhyCPWJhI9Li54R1d9H8Tq6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.6.tgz",
+      "integrity": "sha512-DobZggy3K49xdCpjeyMou0FQhkoYbluVGNydL6D+lcxF8GoAsttFX0xnH5GmiQ89We5dB6TRpW+CD/VowBH6HQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/nested-clients": "^3.997.36",
+        "@aws-sdk/token-providers": "3.1096.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.68",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.68.tgz",
+      "integrity": "sha512-bq+yTt+uWJx60VVp/OIAX5xqUAu/K2Uc3eknWnWl+KtfcU2CQe0uNw6lySrn2t5GKHq7jsV0Z63HiBGVtzr/lg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/nested-clients": "^3.997.36",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.36.tgz",
+      "integrity": "sha512-b71Suv7L+DnhM0MsQHU4WO42I32kxLZi96PbVhZbxMYIoKnEZz3v+LSrG8fupAoA4cBSshCk1Dl/PeRz49qUSg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/fetch-http-handler": "^5.6.10",
+        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1096.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1096.0.tgz",
+      "integrity": "sha512-hdUS2hDppy3vkWeFl5y86RLNU6OWH2mQB09yOSsRefwhhGTSFPkaZvfLDD/9vFcvMzlr8QFQFw3fw2FtrurVQA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.1",
+        "@aws-sdk/nested-clients": "^3.997.36",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.8",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/types": {
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz",
+      "integrity": "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
       }
@@ -26252,14 +26454,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.39.tgz",
-      "integrity": "sha512-8+srXqYIF8KYMLC4FxMLEM5Ek7kUNibJu1R4m8/fUhhNYIZZz26oGtKkCr8I/HiG2fFQxBvaGgQZT4/mqRCSnA==",
+      "version": "3.996.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.42.tgz",
+      "integrity": "sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.0",
-        "@smithy/signature-v4": "^5.6.3",
-        "@smithy/types": "^4.16.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.9",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -26267,12 +26469,12 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/types": {
-      "version": "3.974.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.0.tgz",
-      "integrity": "sha512-QIBrw90CDm4O0UaIIzkU6DrFdeJzEb2Va5EPEVpyldj6sHJxB6cshhStJuhZxk3wR3PmjJlYsjPmY1kNb+KGBg==",
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.16.0",
+        "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -32042,9 +32244,9 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.29.3",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.3.tgz",
-      "integrity": "sha512-L+Ys6ecjk5vwPMAKHBpPKlJ3DkqwNcnfEISXBZIsVvWG/XKXfsAP8mwIYlTeLcd2ElHdesPI8OuOmJSFAPhm6A==",
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.0.tgz",
+      "integrity": "sha512-sylYk2l9d7CmRv8ts8p0SDQUr3VO+HMeS1nrjL6+UtbO8ktJHTOeQ1McX+aAyvGGccp5aZX9eNtdcXrSwzoZaw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -32055,12 +32257,12 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.8.tgz",
-      "integrity": "sha512-q9J7JTiXrAhB8sDp4px97uEPT7CwKH61Co78grdNQvU8QZAdiuaSRhP0tUVf2ogy36RZTrlMU1rBmDEH+cnkiA==",
+      "version": "4.4.15",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.15.tgz",
+      "integrity": "sha512-xYVGrisQqTJWhOnScUhbx8s9H63TMtoxzuUoxG6mP8J+B/YbX3vZxVsgV0xDf43abJnJP0fjP7BkQh7OESwuRA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.3",
+        "@smithy/core": "^3.31.0",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -32144,12 +32346,12 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.6.5",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.5.tgz",
-      "integrity": "sha512-SuqeisTyPoiIPtIYru/sGxGyXzmZ+8nnFOhC+qRPglt06Ebd1yH//CDltZB2J/3WBNVhwfUaZ0EtHB3cm2X32g==",
+      "version": "5.6.12",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.12.tgz",
+      "integrity": "sha512-OpQgP6IGH4j0NJ2zjfYZLjQL85ai+Wi/q51EmZJovXsEwKSvu89qiXUq77Q6EmwZ/hSl7fKpn2Z9mhiDN6OM+Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.3",
+        "@smithy/core": "^3.31.0",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -32365,12 +32567,12 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.5.tgz",
-      "integrity": "sha512-bNqdxTQTxmLbomSmlkZFz8L6B/feQ2HHzw4L2zY7Ecp2XffYAZq2uzdWDdxJHJFbEvqd+SRuluJso0P8+xPdbw==",
+      "version": "4.9.12",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.12.tgz",
+      "integrity": "sha512-dWW5KRt4mnEvjNzbGqGeCuAvgum85Y9ZoyuMQqcTEfapndyVJ1k9BEHK7kdXJZ32enyRmmwcFjMwlB/KgLKI3Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.3",
+        "@smithy/core": "^3.31.0",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -32476,12 +32678,12 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.4.tgz",
-      "integrity": "sha512-B89bpf2t/y/wia6LZ+4JfHXYQT9PnVftsH05rgJKKIStS7r/4XSs9HOjtPoLtgcA6HCW9jVqX5DBbq7E0PAkiQ==",
+      "version": "5.6.11",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.11.tgz",
+      "integrity": "sha512-7HsspeiNCZvZHEJ22vV5L/QYuJdTyJvPJvMrYD3AgkM3IJB0pkln4jkjPvtpTWRMkHXbO8WKwNjoVdVlBFwHmw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.29.3",
+        "@smithy/core": "^3.31.0",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "typecheck:amplify": "tsc -p amplify --noEmit",
     "check": "run-p typecheck lint test",
     "check-all": "run-s format check build:app",
-    "sandbox": "VITE_ALLOW_SIGNUP=true ampx sandbox"
+    "sandbox": "VITE_ALLOW_SIGNUP=true ampx sandbox",
+    "regenerate-thumbnails": "tsx scripts/regenerate-thumbnails.ts"
   },
   "dependencies": {
     "@aws-amplify/ui-react": "^6.13.2",
@@ -50,6 +51,7 @@
   "devDependencies": {
     "@aws-amplify/backend": "^1.19.0",
     "@aws-amplify/backend-cli": "^1.8.1",
+    "@aws-sdk/client-lambda": "^3.1096.0",
     "@aws-sdk/client-s3": "^3.962.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",

--- a/scripts/regenerate-thumbnails.ts
+++ b/scripts/regenerate-thumbnails.ts
@@ -1,0 +1,155 @@
+import { readFile } from "node:fs/promises";
+import { InvokeCommand, LambdaClient, ListFunctionsCommand } from "@aws-sdk/client-lambda";
+import { ListObjectsV2Command, S3Client } from "@aws-sdk/client-s3";
+import { isVideoFile } from "../amplify/functions/thumbnail/utils";
+
+/**
+ * Rebuild the thumbnails of videos that are already stored.
+ *
+ * Thumbnails are only produced when an object is uploaded, so a change to the
+ * frame selection leaves every existing video with the thumbnail its old logic
+ * picked. This walks the stored videos and rebuilds them.
+ *
+ * The Lambda does the work. Running FFmpeg locally would produce thumbnails
+ * without ever exercising the deployed path (layer binaries, function
+ * permissions), which is the part that needs to hold.
+ *
+ * Existing thumbnails are always overwritten: the point is to replace what the
+ * old logic produced, and a black thumbnail is indistinguishable from a good
+ * one without looking at it.
+ *
+ * Images are left alone. Their thumbnails come from Sharp only, and nothing
+ * about that changed.
+ *
+ * ```
+ * npx tsx scripts/regenerate-thumbnails.ts [--bucket=...] [--function=...] [--dry-run]
+ * ```
+ */
+
+const MEDIA_PREFIX = "media/";
+
+/** Deployed functions carry a generated suffix, so match on the part we choose */
+const FUNCTION_HINT = "thumbnail";
+
+const s3 = new S3Client({});
+const lambda = new LambdaClient({});
+
+function option(name: string): string | undefined {
+  return process.argv.find((value) => value.startsWith(`--${name}=`))?.split("=")[1];
+}
+
+/**
+ * Default to the bucket of the current sandbox. Point --bucket at another
+ * environment to rebuild there.
+ */
+async function defaultBucket(): Promise<string> {
+  const outputs: unknown = JSON.parse(await readFile("amplify_outputs.json", "utf8"));
+  const bucket =
+    typeof outputs === "object" && outputs !== null && "storage" in outputs
+      ? (outputs.storage as { bucket_name?: string }).bucket_name
+      : undefined;
+  if (!bucket) {
+    throw new Error("amplify_outputs.json has no bucket. Pass --bucket=");
+  }
+  return bucket;
+}
+
+/**
+ * Resolve which function to call. Refuse to guess when several environments
+ * match: pointing one environment's function at another environment's bucket
+ * is worse than typing the name.
+ */
+async function resolveFunctionName(): Promise<string> {
+  const given = option("function");
+  if (given) {
+    return given;
+  }
+
+  const names: string[] = [];
+  let marker: string | undefined;
+  do {
+    const page = await lambda.send(new ListFunctionsCommand({ Marker: marker }));
+    names.push(...(page.Functions ?? []).flatMap(({ FunctionName }) => FunctionName ?? []));
+    marker = page.NextMarker;
+  } while (marker);
+
+  const candidates = names.filter((name) => name.toLowerCase().includes(FUNCTION_HINT));
+  if (candidates.length !== 1) {
+    throw new Error(`Pass --function=. Candidates: ${candidates.join(", ") || "none"}`);
+  }
+  return candidates[0];
+}
+
+async function videoKeys(bucket: string): Promise<string[]> {
+  const keys: string[] = [];
+  let token: string | undefined;
+  do {
+    const page = await list(bucket, token);
+    keys.push(
+      ...(page.Contents ?? []).flatMap(({ Key }) => (Key && isVideoFile(Key) ? [Key] : [])),
+    );
+    token = page.NextContinuationToken;
+  } while (token);
+  return keys;
+}
+
+async function list(bucket: string, token: string | undefined) {
+  try {
+    return await s3.send(
+      new ListObjectsV2Command({ Bucket: bucket, Prefix: MEDIA_PREFIX, ContinuationToken: token }),
+    );
+  } catch (error) {
+    // The default comes from amplify_outputs.json, which keeps pointing at a
+    // sandbox that was deleted. Say so instead of only passing the S3 error on
+    if (error instanceof Error && error.name === "NoSuchBucket" && !option("bucket")) {
+      throw new Error(
+        `${bucket} does not exist. amplify_outputs.json may be stale, so pass --bucket=`,
+        { cause: error },
+      );
+    }
+    throw error;
+  }
+}
+
+async function main(): Promise<void> {
+  const bucket = option("bucket") ?? (await defaultBucket());
+  const functionName = await resolveFunctionName();
+  const dryRun = process.argv.includes("--dry-run");
+
+  const targets = await videoKeys(bucket);
+  console.log(`${bucket} / ${functionName}`);
+  console.log(`${targets.length} video(s) to rebuild${dryRun ? " (dry run)" : ""}`);
+
+  let failures = 0;
+  for (const key of targets) {
+    if (dryRun) {
+      console.log(`${key}: skipped (dry run)`);
+      continue;
+    }
+
+    const response = await lambda.send(
+      new InvokeCommand({
+        FunctionName: functionName,
+        Payload: JSON.stringify({ bucket, key }),
+      }),
+    );
+    // A direct invocation rethrows its failure, so this is set when the
+    // thumbnail could not be rebuilt
+    if (response.FunctionError) {
+      failures += 1;
+      const payload = response.Payload ? Buffer.from(response.Payload).toString("utf8") : "";
+      console.error(`${key}: ${response.FunctionError} ${payload}`);
+    } else {
+      console.log(`${key}: rebuilt`);
+    }
+  }
+
+  if (failures > 0) {
+    // Finishing successfully with thumbnails still missing would suggest the
+    // run was enough
+    console.error(`${failures} of ${targets.length} video(s) failed`);
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"],
+  "include": ["src", "scripts"],
   "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
サムネイルはアップロード時にしか作られないため、フレーム選択を差し替えても
すでに保存されている動画には旧ロジックが選んだ画が残る。先頭が黒いまま
残ったものを揃える手段が無いので、保存済みの動画を走査して作り直す。

変換は Lambda に任せる。手元の ffmpeg で作って置くこともできるが、それでは
レイヤーのバイナリと関数の権限という、本番で効く経路を確かめないまま実体だけが
揃ってしまう。数十件規模の手作業に CI もキューも要らないので、順に呼ぶ。

呼び出しのために、ハンドラへ { bucket, key } の受け口を足した。S3 通知は鍵を
URL 符号化して渡すため、通知の形を script 側で捏造すると、空白や括弧を含む
ファイル名が壊れる（このアプリの鍵は利用者が付けたファイル名がそのまま入る）。
入口の正規化は requests.ts に分けて、ffmpeg も sharp も読み込まないところで テストできるようにした。

直接呼び出しのときだけ、失敗を投げ直す。通知は複数レコードが来るので 1 件の
失敗で残りを止めないのが正しいが、直接呼び出しは 1 件に対する手作業であり、
ログに埋もれると成否が呼び出し元に伝わらない。スクリプトは FunctionError を
数え、1 件でも失敗したら終了コードを 1 にする。揃っていないのに成功で終わると、
流したことをもって揃ったと見なしてしまう。

既存のサムネイルは常に上書きする。今回の目的が旧ロジックの結果の置き換えで
あり、黒いサムネイルは見るまで良品と区別が付かないため、選別の余地がない。
画像は対象にしない。あちらは sharp だけで作られ、何も変えていない。

環境の取り違えを避けるため、関数名が 1 つに絞れないときは候補を出して止める。
片方の環境の関数にもう片方のバケットを渡す事故は、名前を打つ手間より高くつく。
既定のバケットは amplify_outputs.json から取るが、削除済みサンドボックスを
指したままになることがあるので、NoSuchBucket のときは --bucket を促す。

tsconfig.json の include に scripts を足した。これが無いと typecheck の対象に scripts が入らず、型エラーが実行時まで残る。